### PR TITLE
Updating examples to not provide event id

### DIFF
--- a/go/grpcclient/grpcclient.go
+++ b/go/grpcclient/grpcclient.go
@@ -12,7 +12,6 @@ import (
 	"github.com/developerforce/pub-sub-api-pilot/go/common"
 	"github.com/developerforce/pub-sub-api-pilot/go/oauth"
 	"github.com/developerforce/pub-sub-api-pilot/go/proto"
-	"github.com/google/uuid"
 	"github.com/linkedin/goavro/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -262,7 +261,6 @@ func (c *PubSubClient) Publish(schema *proto.SchemaInfo) error {
 		TopicName: common.TopicName,
 		Events: []*proto.ProducerEvent{
 			{
-				Id:       uuid.New().String(),
 				SchemaId: schema.GetSchemaId(),
 				Payload:  payload,
 			},
@@ -324,7 +322,6 @@ func (c *PubSubClient) PublishStream(schema *proto.SchemaInfo) error {
 		TopicName: common.TopicName,
 		Events: []*proto.ProducerEvent{
 			{
-				Id:       uuid.New().String(),
 				SchemaId: schema.GetSchemaId(),
 				Payload:  payload,
 			},
@@ -389,7 +386,6 @@ func (c *PubSubClient) PublishStream(schema *proto.SchemaInfo) error {
 					TopicName: common.TopicName,
 					Events: []*proto.ProducerEvent{
 						{
-							Id:       uuid.New().String(),
 							SchemaId: schema.GetSchemaId(),
 							Payload:  payload,
 						},

--- a/pubsub_api.proto
+++ b/pubsub_api.proto
@@ -52,7 +52,7 @@ message EventHeader {
  * Event value that is created by an event producing application.
  */
 message ProducerEvent {
-  // The event's system generated unique identifier
+  // The event's system generated guid
   string id = 1;
   // Schema fingerprint for this event which is hash of the schema
   string schema_id = 2;

--- a/pubsub_api.proto
+++ b/pubsub_api.proto
@@ -52,7 +52,7 @@ message EventHeader {
  * Event value that is created by an event producing application.
  */
 message ProducerEvent {
-  // The event's guid
+  // The event's system generated unique identifier
   string id = 1;
   // Schema fingerprint for this event which is hash of the schema
   string schema_id = 2;

--- a/python/InventoryAppExample/InventoryApp.py
+++ b/python/InventoryAppExample/InventoryApp.py
@@ -49,7 +49,6 @@ def generate_producer_events(schema_id, record_id, obj):
         "EstimatedDeliveryDate__c": int(dt.timestamp()),
         "Weight__c": 58.2}
     req = {
-        "id": "234",
         "schema_id": schema_id,
         "payload": obj.encode(schema, payload),
     }

--- a/python/InventoryAppExample/PubSub.py
+++ b/python/InventoryAppExample/PubSub.py
@@ -85,9 +85,9 @@ class PubSub(object):
             res.__dict__)
 
         # Set metadata headers
-        self.metadata = (('x-sfdc-api-session-token', self.session_id),
-                         ('x-sfdc-instance-url', self.url),
-                         ('x-sfdc-tenant-id', self.tenant_id))
+        self.metadata = (('accesstoken', self.session_id),
+                         ('instanceurl', self.url),
+                         ('tenantid', self.tenant_id))
 
     def make_fetch_request(self, topic):
         """
@@ -166,10 +166,9 @@ class PubSub(object):
         payload = {
             "CreatedDate": int(datetime.now().timestamp()),
             "CreatedById": '005R0000000cw06IAA',  # Your user ID
-            "textt__c": 'text ==t Hello World'
+            "textt__c": 'Hello World'
         }
         req = {
-            "id": "261",  # This can be anything
             "schema_id": schema_id,
             "payload": self.encode(schema, payload)
         }

--- a/python/InventoryAppExample/SalesforceListener.py
+++ b/python/InventoryAppExample/SalesforceListener.py
@@ -52,7 +52,7 @@ def process_confirmation(event, pubsub):
             time.sleep(2)
         day = datetime.fromtimestamp(decoded['EstimatedDeliveryDate__c']).strftime('%Y-%m-%d')
         res = requests.patch(my_url + "/services/data/v52.0/sobjects/Opportunity/"
-                             + decoded['OpptyRecordId__c'], json.dumps({"EstimatedDeliveryDate__c": day}),
+                             + decoded['OpptyRecordId__c'], json.dumps({"Description": "Estimated Delivery Date: " + day}),
                              headers={"Authorization": "Bearer " + pubsub.session_id,
                                       "Content-Type": "application/json"})
         print("  Done!", res)


### PR DESCRIPTION
The `id` field while is a system generated field for an event. It is not needed while producing an event from the client side. 
Updating the examples. 