### PR TITLE
Upgrade com.google.protobuf:protoc and io.grpc:protoc-gen-grpc-java to support aarch64

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
+            <version>1.40.1</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -83,9 +83,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.0</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.4.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.58.0:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <avro.version>1.11.0</avro.version>
-        <grpc.version>1.35.1</grpc.version>
+        <grpc.version>1.40.1</grpc.version>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>1.40.1</version>
+            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
When trying to `mvn clean install` the java project on my mac with the M1 chip, I ran into mising artifact errors with `com.google.protobuf:protoc:3.3.0` and `io.grpc:protoc-gen-grpc-java:1.4.0`.  I was able to resolve this with upgrades, but the upgrade to `io.grpc` caused the error detailed [here](https://github.com/grpc/grpc-java/issues/8523) .  I was able to resolve this by upgrading the version of grpc.